### PR TITLE
Add ability to use a repository in mapping

### DIFF
--- a/src/sngrl/SphinxSearch/SphinxSearch.php
+++ b/src/sngrl/SphinxSearch/SphinxSearch.php
@@ -212,7 +212,10 @@ class SphinxSearch
 		$primaryKey = isset($config['primaryKey']) ? $config['primaryKey'] : 'id';
 		    
                 if ($config) {
-                    if (isset($config['modelname'])) {
+                    if (isset($config['repository'])) {
+                        $result = call_user_func_array($config['repository'] . '::findInRange',
+                            array($config['column'], $matchids));
+                    } else if (isset($config['modelname'])) {
                         if ($this->_eager_loads) {
                             $result = call_user_func_array($config['modelname'] . "::whereIn",
                                 array($config['column'], $matchids))->orderByRaw(\DB::raw("FIELD($primaryKey, $idString)"))


### PR DESCRIPTION
Adds ability to use a repository for mapping to objects.
Needs in sphinxsearch.php conf, mapping, an entry to define the
repo like this - 'mapping' => ['repository' => MyRepo::class, ..]
and define a method like MyRepo::findInRange($column, $params)
to map from ids to real objects