### PR TITLE
SetIdRange function.

### DIFF
--- a/src/sngrl/SphinxSearch/SphinxSearch.php
+++ b/src/sngrl/SphinxSearch/SphinxSearch.php
@@ -132,6 +132,21 @@ class SphinxSearch
         return $this;
     }
 
+    /**
+     * Limit the ID range; only match records if document ID is between $min and $max (inclusive)
+     *
+     * @param integer $min minimum document ID
+     * @param integer $max maximum document ID
+     *
+     * @return SphinxClient
+     * @throws \InvalidArgumentException When $min or $max are invalid
+     */
+    public function setIdRange($min, $max)
+    {
+        $this->_connection->setIdRange($min, $max);
+        return $this;
+    }
+
     public function setGeoAnchor($attrlat, $attrlong, $lat = null, $long = null)
     {
         $this->_connection->setGeoAnchor($attrlat, $attrlong, $lat, $long);


### PR DESCRIPTION
Prototype: function SetIDRange ( $min, $max )

Sets an accepted range of document IDs. Parameters must be integers. Defaults are 0 and 0; that combination means to not limit by range.

After this call, only those records that have document ID between $min and $max (including IDs exactly equal to $min or $max) will be matched.