### PR TITLE
Set indexer name method

### DIFF
--- a/src/sngrl/SphinxSearch/SphinxSearch.php
+++ b/src/sngrl/SphinxSearch/SphinxSearch.php
@@ -150,6 +150,16 @@ class SphinxSearch
         return $this;
     }
 
+    /**
+     * @param $index_name
+     * @return $this
+     */
+    public function setIndexName($index_name)
+    {
+        $this->_index_name = $index_name;
+        return $this;
+    }
+
     public function limit($limit, $offset = 0, $max_matches = 1000, $cutoff = 1000)
     {
         $this->_connection->setLimits($offset, $limit, $max_matches, $cutoff);


### PR DESCRIPTION
I create a new method to set the index name, specialy when the devoloper don't need the 'search' method, only 'query'.

In 'query' method, SphinxSearch use the first indexer specified in the configuration file. With this method, the developer can specify the indexer that is needed.

Example:

```
$sphinx = new SphinxSearch();
$sphinx->setMatchMode(\Sphinx\SphinxClient::SPH_MATCH_FULLSCAN);
$sphinx->setFilterFloatRange('@geodist', 0.0, $circle);
$sphinx->setSortMode(SphinxClient::SPH_SORT_ATTR_ASC, '@geodist');
$sphinx->setGeoAnchor('lat', 'lng', $lat, $lng);
$sphinx->limit(5000);
$sphinx->setIndexName('insurance_centers');
$results = $sphinx->query();
```