### PR TITLE
Adding SphinxSearchException

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ $results = $sphinx->search('my query', 'index_name')->query();
 
 Basic query (with Eloquent)
 ```php
-$results = $sphinx->search('my query', 'index_name')->get();
+$results = $sphinx->search('my query', 'index_name')->get(); // Throws SphinxSearchException
 ```
 
 Query another Sphinx index with limit and filters.

--- a/src/sngrl/SphinxSearch/SphinxSearch.php
+++ b/src/sngrl/SphinxSearch/SphinxSearch.php
@@ -233,6 +233,8 @@ class SphinxSearch
             } else {
                 $result = array();
             }
+        } else {
+            throw new SphinxSearchException($this->_connection->GetLastError());
         }
         if ($respect_sort_order) {
             if (isset($matchids)) {

--- a/src/sngrl/SphinxSearch/SphinxSearchException.php
+++ b/src/sngrl/SphinxSearch/SphinxSearchException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace sngrl\SphinxSearch;
+
+use Exception;
+
+class SphinxSearchException extends Exception
+{
+    //
+}


### PR DESCRIPTION
When executing a query that fails via the eloquent method, we have no way to know what the error was.  This pull request adds a SphinxSerachException to be thrown instead of returning `null`.